### PR TITLE
Added support for Ruuvi tag movement counter.

### DIFF
--- a/esp32_ble2mqtt.ino
+++ b/esp32_ble2mqtt.ino
@@ -449,6 +449,7 @@ void mqtt_send() {
     char topic[512];
     short temperature = 0;
     unsigned short humidity;
+    unsigned short movement;
     unsigned short foo;
     int pressure;
     int voltage;
@@ -468,10 +469,11 @@ void mqtt_send() {
                     foo = ((unsigned short)tagdata[curr_tag][20] << 8) + (unsigned short)tagdata[curr_tag][21];
                     voltage = ((double)foo / 32  + 1600);
                     pressure = ((unsigned short)tagdata[curr_tag][12] << 8) + (unsigned short)tagdata[curr_tag][13] + 50000;
+                    movement = ((unsigned short)tagdata[curr_tag][22]);
 
-                    sprintf(json, "{\"type\":%d,\"t\":%d,\"rh\":%d,\"bu\":%d,\"ap\":%d,\"s\":%d}",
+                    sprintf(json, "{\"type\":%d,\"t\":%d,\"rh\":%d,\"bu\":%d,\"ap\":%d,\"s\":%d,\"mo\":%d}",
                             tagtype[curr_tag], int(temperature * .05), int((float)humidity * .0025),
-                            voltage, int(pressure / 100), abs(tagrssi[curr_tag]));
+                            voltage, int(pressure / 100), abs(tagrssi[curr_tag]), movement);
                 }
             }
             // Other tags --------------------------------------------------------------------------------------


### PR DESCRIPTION
Added support for Ruuvi tag movement counter.
Use case for this: I glued one tag on my mailbox and the counter increments whenever I get mail delivered. And with this change, I don't need to set up a separate poller to get the movement count.