### PR TITLE
Arduino ESP32 library version 3.0 support + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and [OH2MP ESP32 Ruuvicollector](https://github.com/oh2mp/esp32_ruuvicollector)
 Install these from the IDE library manager. I have added the versions which have tested and confirmed to be working.
 
 - EspMQTTClient 1.13.3
-- LittleFS_esp32 1.0.6 (1.0.7 is buggy)
+- LittleFS_esp32 1.0.5 (1.0.6 won't compile, see https://github.com/lorol/LITTLEFS/issues/69)
 - PubSubClient 2.8
 
 ## Installation and configuration

--- a/esp32_ble2mqtt.ino
+++ b/esp32_ble2mqtt.ino
@@ -18,6 +18,8 @@
 #include <BLEScan.h>
 #include <BLEAdvertisedDevice.h>
 
+#include "esp_mac.h"
+
 #include <PubSubClient.h>
 
 // #define CONFIG_LITTLEFS_SPIFFS_COMPAT 1
@@ -427,7 +429,7 @@ void setup() {
 
     // Append last 3 octets of MAC to the default hostname
     uint8_t mymac[6];
-    esp_read_mac(mymac, (esp_mac_type_t)0); // 0:wifi station, 1:wifi softap, 2:bluetooth, 3:ethernet
+    esp_read_mac(mymac, ESP_MAC_WIFI_STA); 
     char mac_end[8];
     sprintf(mac_end, "%02x%02x%02x", mymac[3], mymac[4], mymac[5]);
     strcat(myhostname, mac_end);

--- a/esp32_ble2mqtt.ino
+++ b/esp32_ble2mqtt.ino
@@ -98,7 +98,7 @@ uint8_t heardtagtype[MAX_TAGS];
 
 File file;
 BLEScan* blescan;
-BLEScanResults foundDevices;
+BLEScanResults* foundDevices;
 BLEClient *pClient;
 BLERemoteService *pRemoteService;
 BLERemoteCharacteristic *rCharacteristic;
@@ -682,7 +682,7 @@ void mqtt_send() {
     This task handles BLE scanning and possible GATT request to an Alpicool fridge
 */
 void ble_task(void *parameter) {
-  //BLEScanResults foundDevices;
+
   task_counter = 0;
 
   while (1) {
@@ -696,7 +696,7 @@ void ble_task(void *parameter) {
       /*  Something is wrong if zero known tags is heard, so then reboot.
           Possible if all of them are out of range too, but that should not happen anyway.
       */
-      if (foundDevices.getCount() == 0 && tagcount > 0) ESP.restart();
+      if (foundDevices->getCount() == 0 && tagcount > 0) ESP.restart();
       Serial.printf("============= end scan\n");
   
       if (alpicool_index != 0xFF) {
@@ -760,7 +760,7 @@ void startPortal() {
     blescan->setActiveScan(true);
     blescan->setInterval(100);
     blescan->setWindow(99);
-    BLEScanResults foundDevices = blescan->start(11, false);
+    BLEScanResults* foundDevices = blescan->start(11, false);
     blescan->stop();
     blescan->clearResults();
     blescan = NULL;

--- a/esp32_ble2mqtt.ino
+++ b/esp32_ble2mqtt.ino
@@ -719,7 +719,8 @@ void ble_task(void *parameter) {
           // See: https://github.com/klightspeed/BrassMonkeyFridgeMonitor
           if (wCharacteristic != nullptr && alpicool_heard) {
               Serial.println("Sending query to Alpicool fridge: fefe03010200");
-              wCharacteristic->writeValue({0xfe, 0xfe, 3, 1, 2, 0}, 6);
+              uint8_t data[] = {0xfe, 0xfe, 3, 1, 2, 0};
+              wCharacteristic->writeValue(data, 6);
           }
           vTaskDelay(1000 / portTICK_PERIOD_MS); // give one second
           pClient->disconnect();

--- a/esp32_ble2mqtt.ino
+++ b/esp32_ble2mqtt.ino
@@ -434,12 +434,9 @@ void setup() {
     sprintf(mac_end, "%02x%02x%02x", mymac[3], mymac[4], mymac[5]);
     strcat(myhostname, mac_end);
 
-    ledcSetup(LED_R, 5000, 8);
-    ledcAttachPin(LED_R_PIN, LED_R);
-    ledcSetup(LED_G, 5000, 8);
-    ledcAttachPin(LED_G_PIN, LED_G);
-    ledcSetup(LED_B, 5000, 8);
-    ledcAttachPin(LED_B_PIN, LED_B);
+    ledcAttachChannel(LED_R_PIN, 5000, 8, LED_R);
+    ledcAttachChannel(LED_G_PIN, 5000, 8, LED_G);
+    ledcAttachChannel(LED_B_PIN, 5000, 8, LED_B);
     led_fx();
     set_led(0, 0, 0);
 

--- a/esp32_ble2mqtt.ino
+++ b/esp32_ble2mqtt.ino
@@ -417,14 +417,13 @@ void setup() {
     settimeofday(tv, NULL);
 
     // Prepare watchdog
-    timer = timerBegin(0, 240, true);
-    timerAttachInterrupt(timer, &reset_esp32, true);
+    timer = timerBegin(333333);
+    timerAttachInterrupt(timer, &reset_esp32);
     if (interval > 0) {
-        timerAlarmWrite(timer, interval * 180E+6 + 15E+6, false); // set time to 3x interval (µs) +15s
+        timerAlarm(timer, interval * 180E+6 + 15E+6, false , 0); // set time to 3x interval (µs) +15s
     } else {
-        timerAlarmWrite(timer, 195E+6, false);                  // if interval < 1, set it to 3m 15s
+        timerAlarm(timer, 195E+6, false, 0);                  // if interval < 1, set it to 3m 15s
     }
-    timerAlarmEnable(timer);
 
     // Append last 3 octets of MAC to the default hostname
     uint8_t mymac[6];

--- a/esp32_ble2mqtt.ino
+++ b/esp32_ble2mqtt.ino
@@ -692,11 +692,11 @@ void ble_task(void *parameter) {
       Serial.printf("============= start scan at %d seconds\n", int(millis()/1000));
       scanning = true;
       foundDevices = blescan->start(11, false);
-      blescan->clearResults();
       /*  Something is wrong if zero known tags is heard, so then reboot.
           Possible if all of them are out of range too, but that should not happen anyway.
       */
       if (foundDevices->getCount() == 0 && tagcount > 0) ESP.restart();
+      blescan->clearResults();
       Serial.printf("============= end scan\n");
   
       if (alpicool_index != 0xFF) {


### PR DESCRIPTION
Arduino ESP32 libraries version 3.0 introduced a lot of breaking changes. This is a series of commits to migrate code to be compatible with 3.x.
https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html

Readme change for correct littlefs version.
